### PR TITLE
feat: category mapping for better url display

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,11 +7,31 @@ import sitemap from "@astrojs/sitemap";
 // https://astro.build/config
 export default defineConfig({
   site: THEME_CONFIG.website,
+  prefetch: true,
+  markdown: {
+    shikiConfig: {
+      // Use build-in Shiki theme
+      // https://github.com/shikijs/shiki/blob/main/docs/themes.md
+      theme: 'one-dark-pro',
+      // Or visit here for more themes
+      // https://shikiji.netlify.app/guide/dual-themes#light-dark-dual-themes
+      // experimentalThemes: {
+      //   light: 'github-light',
+      //   dark: 'github-dark',
+      // },
+      // Add your customized languages
+      // Note that shiki has many build-in langs including .astro！
+      // https://github.com/shikijs/shiki/blob/main/docs/languages.md
+      langs: [],
+      // auto wrap for better display
+      wrap: true,
+    },
+  },
   integrations: [
     UnoCSS({
       injectReset: true
     }),
-    robotsTxt(), 
+    robotsTxt(),
     sitemap()
   ]
 });

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -24,7 +24,12 @@ declare namespace App {
       navs: Array<{
         name: string;
         href: string;
-      }>
+      }>,
+      /** category mapping */
+      category_map: Array<{
+        name: string;
+        path: string;
+      }>,
     }
     translate: (key: string, param?: string | number) => string;
   }

--- a/src/pages/categories/[...category].astro
+++ b/src/pages/categories/[...category].astro
@@ -1,26 +1,28 @@
 ---
 import LayoutDefault from '~/layouts/LayoutDefault.astro'
 import ListSection from '~/components/ListSection.astro'
-import { getCategories, formatDate } from '~/utils'
+import { getCategories, formatDate, getPathFromCategory } from '~/utils'
 import ListItem from '~/components/ListItem.astro'
+import { THEME_CONFIG } from '~/theme.config'
 
 export async function getStaticPaths() {
   const categories = await getCategories()
   return Array.from(categories).map(([key, value]) => {
+    const path = getPathFromCategory(key, THEME_CONFIG.category_map);
     return {
-      params: { category: key },
+      params: { category: path, name: key },
       props: { posts: value },
     }
   })
 }
 
 const { posts } = Astro.props
-const { category } = Astro.params
+const { category, name } = Astro.params
 
 ---
 
 <LayoutDefault>
-  <ListSection title={category}>
+  <ListSection title={name}>
     {posts.map((post) => <ListItem title={post.data.title} href={`/posts/${post.slug}/`} description={formatDate(post.data.pubDate)} />)}
   </ListSection>
 </LayoutDefault>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -2,15 +2,16 @@
 import ListItem from '~/components/ListItem.astro'
 import ListSection from '~/components/ListSection.astro'
 import LayoutDefault from '~/layouts/LayoutDefault.astro'
-import { getCategories } from '~/utils/index'
+import { getCategories, getPathFromCategory } from '~/utils/index'
 
 const { translate: t } = Astro.locals
+const { category_map } = Astro.locals.config;
 
 const categories = await getCategories()
 ---
 
 <LayoutDefault>
   <ListSection title={t('Categories')}>
-    {Array.from(categories).map(([key, value]) => <ListItem title={key} href={`/categories/${key}`} description={t('categories_count', value.length)} />)}
+    {Array.from(categories).map(([key, value]) => <ListItem title={key} href={`/categories/${getPathFromCategory(key, category_map)}`} description={t('categories_count', value.length)} />)}
   </ListSection>
 </LayoutDefault>

--- a/src/theme.config.ts
+++ b/src/theme.config.ts
@@ -48,6 +48,10 @@ export const THEME_CONFIG: App.Locals['config'] = {
       name: "About",
       href: "/about",
     },
+  ],
+  /** your category name mapping, which the `path` will be shown in the url */
+  category_map: [
+    {name: "胡适", path: "hu-shi"},
   ]
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -50,3 +50,8 @@ export function formatDate(date?: Date) {
 
   return `${year}-${month}-${day}`
 }
+
+export function getPathFromCategory(category: string, category_map: {name: string, path: string}[]) {
+  const mappingPath = category_map.find(l => l.name === category)
+  return mappingPath ? mappingPath.path : category
+}


### PR DESCRIPTION
目前 `category` 在路径上是原始的URL编码，而一般是实践是有名称到路径的映射。例如 `categories/魯迅` 的实际路径是`/categories/%E9%AD%AF%E8%BF%85`，比较影响链接分享。

配置映射后可以显示 `path` 而非 `name`。同时设置了 fallback 即便不配置也不影响原有功能。
```ts
  category_map: [
    {name: "胡适", path: "hu-shi"},
  ]
```