### PR TITLE
refactor: optimize copy button style

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,20 +10,8 @@ export default defineConfig({
   prefetch: true,
   markdown: {
     shikiConfig: {
-      // Use build-in Shiki theme
-      // https://github.com/shikijs/shiki/blob/main/docs/themes.md
       theme: 'one-dark-pro',
-      // Or visit here for more themes
-      // https://shikiji.netlify.app/guide/dual-themes#light-dark-dual-themes
-      // experimentalThemes: {
-      //   light: 'github-light',
-      //   dark: 'github-dark',
-      // },
-      // Add your customized languages
-      // Note that shiki has many build-in langs including .astro！
-      // https://github.com/shikijs/shiki/blob/main/docs/languages.md
       langs: [],
-      // auto wrap for better display
       wrap: true,
     },
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@astrojs/check": "^0.3.4",
     "@astrojs/rss": "^4.0.4",
     "@astrojs/sitemap": "^3.0.5",
+    "@github/clipboard-copy-element": "^1.3.0",
     "astro": "^4.5.9",
     "astro-robots-txt": "^1.0.0",
     "astro-seo": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@astrojs/sitemap':
     specifier: ^3.0.5
     version: 3.1.1
+  '@github/clipboard-copy-element':
+    specifier: ^1.3.0
+    version: 1.3.0
   astro:
     specifier: ^4.5.9
     version: 4.5.9(@types/node@20.11.24)(typescript@5.3.3)
@@ -833,6 +836,10 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /@github/clipboard-copy-element@1.3.0:
+    resolution: {integrity: sha512-wyntkQkwoLbLo+Hqg2LIVMXDIzcvUb9bSDz+clX6nVJItwzh103rHxdXFRZD+DmxVbuEW5xSznYQXkz1jZT+xg==}
+    dev: false
 
   /@iconify-json/mdi@1.1.64:
     resolution: {integrity: sha512-zGeo5TjhNFAY6FmSDBLAzDO811t77r6v/mDi7CAL9w5eXqKez6bIjk8R9AL/RHIeq44ALP4Ozr4lMqFTkHr7ug==}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -22,79 +22,72 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>
 
 const { entry, prev, next } = Astro.props
 const { Content } = await entry.render()
-const { translate: t} = Astro.locals
+const { translate: t } = Astro.locals
 ---
 
-<LayoutDefault
-  title={entry.data.title}
-  desc={entry.data.description}
-  banner={entry.data.banner}
->
+<LayoutDefault title={entry.data.title} desc={entry.data.description} banner={entry.data.banner}>
   <Post post={entry}>
     <Content />
   </Post>
   <Pagination
-      showLeft={Boolean(prev)}
-      leftTitle={`${t('prev_post')}: ${prev?.data.title}`}
-      leftUrl={`/posts/${prev?.slug}/`}
-      showRight={Boolean(next)}
-      rightTitle={`${t('next_post')}: ${next?.data.title}`}
-      rightUrl={`/posts/${next?.slug}/`}
-      showPageCount={false}
-    />
+    showLeft={Boolean(prev)}
+    leftTitle={`${t('prev_post')}: ${prev?.data.title}`}
+    leftUrl={`/posts/${prev?.slug}/`}
+    showRight={Boolean(next)}
+    rightTitle={`${t('next_post')}: ${next?.data.title}`}
+    rightUrl={`/posts/${next?.slug}/`}
+    showPageCount={false}
+  />
 </LayoutDefault>
 
-
 <script>
-  const copyButtonLabel = "Copy";
-  const codeBlocks = Array.from(document.querySelectorAll("pre"));
+  import '@github/clipboard-copy-element'
 
-  for (let codeBlock of codeBlocks) {
-    let wrapper = document.createElement("div");
-    wrapper.style.position = "relative";
-
-    let copyButton = document.createElement("button");
-    copyButton.className = "copy-code";
-    copyButton.innerHTML = copyButtonLabel;
-
-    codeBlock.setAttribute("tabindex", "0");
-    codeBlock.appendChild(copyButton);
-
-    codeBlock.parentNode?.insertBefore(wrapper, codeBlock);
-    wrapper.appendChild(codeBlock);
-
-    copyButton.addEventListener("click", async () => {
-      await copyCode(codeBlock, copyButton);
-    });
-  }
-
-  async function copyCode(block: HTMLPreElement, button: HTMLButtonElement) {
-    let code = block.querySelector("code");
-    let text = code?.innerText;
-
-    await navigator.clipboard.writeText(text ?? "");
-
-    button.innerText = "Code Copied";
-
+  document.addEventListener('clipboard-copy', function (event) {
+    const target = event.target as HTMLElement
+    const icon = target.querySelector('.icon') as HTMLElement
+    icon.classList.replace('i-mdi-content-copy', 'i-mdi-check')
     setTimeout(() => {
-      button.innerText = copyButtonLabel;
-    }, 700);
+      icon.classList.replace('i-mdi-check', 'i-mdi-content-copy')
+    }, 1500)
+  })
+
+  const codeBlocks = Array.from(document.querySelectorAll('pre'))
+  const icon = "<div class='i-mdi-content-copy icon text-white'></div>"
+  for (let codeBlock of codeBlocks) {
+    let wrapper = document.createElement('div')
+    wrapper.className = 'code-container'
+
+    let copyButton = document.createElement('clipboard-copy')
+    let code = codeBlock.querySelector('code')
+    copyButton.value = code?.innerText ?? ''
+    copyButton.className = 'clipboard-copy'
+    copyButton.innerHTML = icon
+
+    codeBlock.appendChild(copyButton)
+
+    codeBlock.parentNode?.insertBefore(wrapper, codeBlock)
+    wrapper.appendChild(codeBlock)
   }
 </script>
 
 <style is:global>
-  .copy-code {
+  .code-container {
+    position: relative;
+  }
+  .clipboard-copy {
     position: absolute;
-    top: 0;
-    right: 0;
-    background-color: #3730a3;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    line-height: 1rem;
-    border-radius: 0 0 0 0.25rem;
+    top: .5rem;
+    right: .5rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.25rem;
   }
 
-  .copy-code:hover {
-    background-color: #312e81;
+  .clipboard-copy:hover {
+    background-color: #30363d;
   }
 </style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": {
       "~/*": ["src/*"]
     },
+    "lib": ["esnext", "dom"],
   },
 }


### PR DESCRIPTION
This PR resolves #15 

- Replaced the copy functionality with [\<clipboard-copy\> element](https://github.com/github/clipboard-copy-element) 
- Optimized copy button style

![录屏2024-04-02 17 25 13](https://github.com/moeyua/astro-theme-typography/assets/45156493/30c24cb8-5519-46ea-892e-d57b3dd3553c)
