### PR TITLE
fix: fix post category url jump with mapping config

### DIFF
--- a/src/components/Post.astro
+++ b/src/components/Post.astro
@@ -1,11 +1,16 @@
 ---
-import { formatDate } from '~/utils'
+import { formatDate, getPathFromCategory } from '~/utils'
+import { THEME_CONFIG } from '~/theme.config'
 interface Props {
   post: Post
 }
 
 const { post } = Astro.props
 const { translate: t } = Astro.locals
+
+function getCategoryUrl(category: string) {
+  return `/categories/${getPathFromCategory(category, THEME_CONFIG.category_map)}`
+}
 ---
 
 <article class="heti">
@@ -19,7 +24,7 @@ const { translate: t } = Astro.locals
       {
         post.data.categories &&
           post.data.categories.map((category) => (
-            <a class="ml-2.5" href={`/categories/${category}`}>
+            <a class="ml-2.5" href={getCategoryUrl(category)}>
               # {category}
             </a>
           ))


### PR DESCRIPTION
Fixes the category URL jump issue on the post page when utilizing category name mapping configuration.