### PR TITLE
 fix: remove background color from code blocks #138

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -72,7 +72,7 @@ article.heti a:has(code):hover {
   background-color: transparent;
 }
 
-article.heti code {
+article.heti :where(:not(pre) > code) {
   padding: 2px 4px;
   font-size: 90%;
   color: #c7254e;


### PR DESCRIPTION
这个 Pull Request 解决了 Issue #138，取消了代码块的底色高亮。具体更改如下：

调整了文章中代码块的样式，使用了更精确的 CSS 选择器来选择代码块中的代码。