### PR TITLE
 feat: add support for draft posts

### DIFF
--- a/scripts/create-post.ts
+++ b/scripts/create-post.ts
@@ -13,33 +13,28 @@ createPost()
  */
 async function createPost(): Promise<void> {
   consola.start('Ready to create a new post!')
-  const filename: string = await consola.prompt('Enter file name: ', {
-    type: 'text',
-  })
-  const ext: string = await consola.prompt('Select file extension: ', {
-    type: 'select',
-    options: ['.md', '.mdx'],
-  })
+
+  const filename: string = await consola.prompt('Enter file name: ', { type: 'text' })
+  const extension: string = await consola.prompt('Select file extension: ', { type: 'select', options: ['.md', '.mdx'] })
+  const isDraft: boolean = await consola.prompt('Is this a draft?', { type: 'confirm', initial: true })
 
   const targetDir = './src/content/posts/'
-  const fullPath: string = path.join(targetDir, `${filename}${ext}`)
+  const fullPath: string = path.join(targetDir, `${filename}${extension}`)
 
-  const frontmatter = `---
-title: ${filename}
-pubDate: ${getDate()}
-categories: []
-description: ''
-slug: ${toSlug(filename)}
----`
+  const frontmatter = getFrontmatter({
+    title: filename,
+    pubDate: dayjs().format('YYYY-MM-DD'),
+    categories: '[]',
+    description: '\'\'',
+    slug: filename.toLowerCase().replace(/\s+/g, '-'),
+    draft: isDraft ? 'true' : 'false',
+  })
 
   try {
     fs.writeFileSync(fullPath, frontmatter)
     consola.success('New post created successfully!')
 
-    const open: boolean = await consola.prompt('Open the new post?', {
-      type: 'confirm',
-      initial: true,
-    })
+    const open: boolean = await consola.prompt('Open the new post?', { type: 'confirm', initial: true })
     if (open) {
       consola.info(`Opening ${fullPath}...`)
       execSync(`code "${fullPath}"`)
@@ -51,24 +46,14 @@ slug: ${toSlug(filename)}
 }
 
 /**
- * Get the current date in the format "YYYY-MM-DD".
- * @returns The current date as a string.
+ * Create frontmatter from a data object.
+ * @param data The data object to convert to frontmatter.
+ * @returns The frontmatter as a string.
  */
-function getDate(): string {
-  // const today: Date = new Date()
-  // const year: number = today.getFullYear()
-  // const month: string = String(today.getMonth() + 1).padStart(2, '0')
-  // const day: string = String(today.getDate()).padStart(2, '0')
-  // return `${year}-${month}-${day}`
+function getFrontmatter(data: { [key: string]: string }): string {
+  const frontmatter = Object.entries(data)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n')
 
-  return dayjs().format('YYYY-MM-DD')
-}
-
-/**
- * Convert a string to a slug: lowercase and replace spaces with hyphens.
- * @param str The string to convert.
- * @returns The converted slug.
- */
-function toSlug(str: string): string {
-  return str.toLowerCase().replace(/\s+/g, '-')
+  return `---\n${frontmatter}\n---`
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -6,21 +6,18 @@ const posts = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      description: z.string().optional(),
       pubDate: z.coerce.date(),
+      categories: z.array(z.string()),
+      draft: z.boolean().default(false).optional(),
+      description: z.string().optional(),
       customData: z.string().optional(),
       banner: image()
-        .refine(img => Math.max(img.width, img.height) <= 4096, {
-          message: 'Width and height of the banner must less than 4096 pixels',
-        })
+        .refine(img => Math.max(img.width, img.height) <= 4096, { message: 'Width and height of the banner must less than 4096 pixels' })
         .optional(),
-      categories: z.array(z.string()),
       author: z.string().optional(),
       commentsUrl: z.string().optional(),
       source: z.optional(z.object({ url: z.string(), title: z.string() })),
-      enclosure: z.optional(
-        z.object({ url: z.string(), length: z.number(), type: z.string() }),
-      ),
+      enclosure: z.optional(z.object({ url: z.string(), length: z.number(), type: z.string() })),
     }),
 })
 

--- a/src/content/posts/Latex Example.md
+++ b/src/content/posts/Latex Example.md
@@ -4,6 +4,7 @@ pubDate: 2023-10-01
 categories: ["Examples"]
 description: "Here is a sample of some basic Latex syntax that can be used when writing Latex content in Astro."
 slug: latex-example
+draft: true
 ---
 
 In this post, we will showcase some basic LaTeX syntax that can be used when writing LaTeX content in Astro.

--- a/src/content/posts/Markdown Example.md
+++ b/src/content/posts/Markdown Example.md
@@ -4,6 +4,7 @@ pubDate: 2023-10-01
 categories: ["Examples"]
 description: "Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro."
 slug: markdown-example
+draft: true
 ---
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,6 +26,9 @@ export async function getPosts() {
   posts.sort((a, b) => {
     return dayjs(a.data.pubDate).isBefore(dayjs(b.data.pubDate)) ? 1 : -1
   })
+  if (import.meta.env.PROD) {
+    return posts.filter(post => post.data.draft !== true)
+  }
   return posts
 }
 


### PR DESCRIPTION
This pull request includes multiple changes to the `scripts/create-post.ts`, `src/content.config.ts`, `src/content/posts`, and `src/utils/index.ts` files to enhance the post creation process and manage draft posts. The most important changes include adding a draft option to posts, refactoring the frontmatter creation, and updating the content schema and utility functions.

Enhancements to post creation:

* [`scripts/create-post.ts`](diffhunk://#diff-ca95cdd17caa16f91c4bf3ab7092138c9b109f93d2d053ce2ae327c793a03973L16-R37): Added a prompt to mark posts as drafts and refactored the frontmatter creation by introducing a new `getFrontmatter` function. [[1]](diffhunk://#diff-ca95cdd17caa16f91c4bf3ab7092138c9b109f93d2d053ce2ae327c793a03973L16-R37) [[2]](diffhunk://#diff-ca95cdd17caa16f91c4bf3ab7092138c9b109f93d2d053ce2ae327c793a03973L54-R58)

Content schema updates:

* [`src/content.config.ts`](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L9-R20): Updated the schema to include a `draft` boolean field with a default value of `false`.

Post metadata updates:

* [`src/content/posts/Latex Example.md`](diffhunk://#diff-89cdfaa4bd100e7cc2eb479e8e4ab5a5f2c1ea2cba1acb664ee6341f92b96736R7): Added the `draft: true` field to the frontmatter.
* [`src/content/posts/Markdown Example.md`](diffhunk://#diff-4db083eaeb8e1897b9d77210d962fecb11158c4e5471d2c4fca045a09a267d88R7): Added the `draft: true` field to the frontmatter.

Utility function updates:

* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99R29-R31): Modified the `getPosts` function to filter out draft posts in production.