### PR TITLE
Add OS-based theme switching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ And then add the corresponding page in `src/pages`, see more in [Astro Pages](ht
 Typography supports dark mode. You can change it in the config file:
 
 ```ts
-themeStyle: 'dark' // 'light' | 'dark'
+themeStyle: 'dark' // 'light' | 'dark' | 'system'
 ```
 
 ### Internationalization (i18n)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,7 +113,7 @@ navs: [
 「活版印字」主题支持深色模式。您可以在配置文件中更改它：
 
 ```ts
-themeStyle: 'dark' // 'light' | 'dark'
+themeStyle: 'dark' // 'light' | 'dark' | 'system'
 ```
 
 ### 国际化 (i18n)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,7 +113,7 @@ navs: [
 「活版印字」主题支持深色模式。您可以在配置文件中更改它：
 
 ```ts
-themeStyle: 'dart' // 'light' | 'dark'
+themeStyle: 'dark' // 'light' | 'dark'
 ```
 
 ### 国际化 (i18n)

--- a/src/.config/default.ts
+++ b/src/.config/default.ts
@@ -55,7 +55,7 @@ export const defaultConfig: ThemeConfig = {
     ],
   },
   appearance: {
-    theme: 'light',
+    theme: 'system',
     locale: 'zh-cn',
     colorsLight: {
       primary: '#2e405b',

--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,0 +1,33 @@
+---
+import { themeConfig } from "~/.config";
+
+const theme = themeConfig.appearance.theme;
+---
+
+<script is:inline define:vars={{ theme }}>
+  function updateTheme(theme) {
+    // Check if theme is system
+    if (theme === "system") {
+      // Check OS preference
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      document.documentElement.classList.toggle("dark", prefersDark);
+    } else {
+      // Set theme directly
+      document.documentElement.classList.toggle("dark", theme === "dark");
+    }
+  }
+
+  // Initial theme setup
+  updateTheme(theme);
+
+  // Listen for OS theme changes
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (e) => {
+      if (theme === "system") {
+        document.documentElement.classList.toggle("dark", e.matches);
+      }
+    });
+</script>

--- a/src/layouts/LayoutDefault.astro
+++ b/src/layouts/LayoutDefault.astro
@@ -6,6 +6,7 @@ import SiteTitle from '~/components/SiteTitle.astro'
 import SiteSeo from '~/components/SiteSeo.astro'
 import LaTeX from '~/components/LaTeX.astro'
 import Analytics from '~/components/Analytics.astro'
+import ThemeScript from '~/components/ThemeScript.astro'
 import '~/styles/global.css'
 
 const lang = themeConfig.appearance.locale ?? 'en-us'
@@ -17,6 +18,7 @@ const dark = themeConfig.appearance.theme === 'dark'
     <slot name="seo"> <SiteSeo /> </slot>
     <LaTeX />
     <Analytics />
+    <ThemeScript />
   </head>
 
   <body

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -40,7 +40,7 @@ export interface ConfigSite {
 }
 
 export interface ConfigAppearance {
-  theme: 'light' | 'dark'
+  theme: 'light' | 'dark' | 'system'
   locale: keyof typeof LANGUAGES
   colorsDark: Colors
   colorsLight: Colors


### PR DESCRIPTION
This PR adds support for automatically switching between light and dark themes based on the user's operating system preferences. Also fix a typo in Chinese README: `dart` -> `dark`.