### PR TITLE
fix: 修复了黑暗模式下字体过暗的问题

### DIFF
--- a/src/layouts/LayoutPost.astro
+++ b/src/layouts/LayoutPost.astro
@@ -9,7 +9,7 @@ interface Props {
 const { post } = Astro.props
 ---
 
-<article class="prose">
+<article class="prose dark:prose-invert">
   <PostMeta post={post} />
   <slot />
 </article>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ const { Content } = await render(aboutPost)
       <time>{formatDate(aboutPost.data.pubDate)}</time>
     </div>
   </header>
-  <article class="prose">
+  <article class="prose dark:prose-invert">
     <Content />
   </article>
 </LayoutDefault>


### PR DESCRIPTION
Fix #248 

将文件`LayoutPost.astro`和`about.astro`中的：
```
<article class="prose">
```
改为了：
```
<article class="prose dark:prose-invert">
```

文件`LayoutPostList`由于未被使用，故保留未做改动。